### PR TITLE
develop

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -144,6 +144,8 @@ services:
     labels:
       - traefik.enable=true
       - traefik.http.routers.pgadmin.rule=HostRegexp(`pgadmin.$TRAEFIK_BASE_HOST`)
+      - traefik.http.routers.pgadmin.tls=true
+      - traefik.http.routers.pgadmin.tls.certresolver=letsencrypt
     restart: $PGADMIN_RESTART_POLICY
   phpmyadmin:
     image: phpmyadmin:$PHPMYADMIN_VERSION


### PR DESCRIPTION
- Update LICENSE Year
- Removing binds for ssh ports
- Using environment variable for appsmith version
- Environment variable for restart policy
- Update appsmith version
- Restart policy for appsmith, vscode, traefik and pgadmin
- Environment variables for archlinux
- Environment variables for debian
- Environment variables for fedora
- Environment variables for gitea
- Environment variables for grafana
- Environment variables for loki
- Environment variables for matomo
- Environment variables for mautic
- Environment variables for metabase
- Environment variables for mongo
- Environment variables for mysql
- Environment variables for nextcloud
- Environment variables for nginx
- Environment variables for phpmyadmin
- Environment variables for portainer
- Environment variables for postgres
- Environment variables for prometheus
- Environment variables for promtail
- Environment variables for rabbitmq
- Environment variables for redis
- Environment variables for redisinsight
- Environment variables for rethinkdb
- Environment variables for sonarqube
- Environment variables for sonic
- Environment variables for sqlserver
- Environment variables for ubuntu
- Environment variables for verdaccio
- Environment variables for wordpress
- Default variables for mysql and mautic
- Fixing mautic smoke test
- Fixing CI tests
- Fixing nginx smoke test:
- Traefik SSL for pgadmin
