### PR TITLE
develop

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -71,11 +71,6 @@ services:
     image: matomo:${MATOMO_VERSION-4.11.0}
     ports:
       - 8086:80
-    environment:
-      MATOMO_DATABASE_HOST: ${MATOMO_DATABASE_HOST-}
-      MATOMO_DATABASE_USERNAME: ${MATOMO_DATABASE_USERNAME-}
-      MATOMO_DATABASE_PASSWORD: ${MATOMO_DATABASE_PASSWORD-}
-      MATOMO_DATABASE_DBNAME: ${MATOMO_DATABASE_DBNAME-}
     labels:
       - traefik.enable=true
       - traefik.http.routers.matomo.rule=Host(`matomo.${TRAEFIK_BASE_HOST-localhost}`)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -69,6 +69,7 @@ services:
     restart: ${LOKI_RESTART_POLICY-no}
   matomo:
     image: matomo:${MATOMO_VERSION-4.11.0}
+    container_name: ${MATOMO_CONTAINER_NAME-}
     ports:
       - 8086:80
     labels:
@@ -90,6 +91,7 @@ services:
     restart: ${MAUTIC_RESTART_POLICY-no}
   metabase:
     image: metabase/metabase:${METABASE_VERSION-v0.44.3}
+    container_name: ${METABASE_CONTAINER_NAME-}
     ports:
       - 3001:3000
     environment: 

--- a/docs/matomo.md
+++ b/docs/matomo.md
@@ -8,11 +8,7 @@ docker compose up -d matomo
 
 ## Environment variables
 
-| **Name**                 | **Default**  |
-| ------------------------ | ------------ |
-| MATOMO_VERSION           | 4.11.0       |
-| MATOMO_DATABASE_HOST     |              |
-| MATOMO_DATABASE_USERNAME |              |
-| MATOMO_DATABASE_PASSWORD |              |
-| MATOMO_DATABASE_DBNAME   |              |
-| MATOMO_RESTART_POLICY    | no           |
+| **Name**                 | **Default** |
+| ------------------------ | ----------- |
+| MATOMO_VERSION           | 4.11.0      |
+| MATOMO_RESTART_POLICY    | no          |

--- a/docs/matomo.md
+++ b/docs/matomo.md
@@ -11,4 +11,5 @@ docker compose up -d matomo
 | **Name**                 | **Default** |
 | ------------------------ | ----------- |
 | MATOMO_VERSION           | 4.11.0      |
+| MATOMO_CONTAINER_NAME    |             |
 | MATOMO_RESTART_POLICY    | no          |

--- a/docs/metabase.md
+++ b/docs/metabase.md
@@ -11,4 +11,5 @@ docker compose up -d metabase
 | **Name**                | **Default** |
 | ----------------------- | ----------- |
 | METABASE_VERSION        | v0.44.3     |
+| METABASE_CONTAINER_NAME |             |
 | METABASE_RESTART_POLICY | no          |


### PR DESCRIPTION
- Removing unnecessary environment variables for matomo service
- Environment variables for both container names: matomo and metabase
