### PR TITLE
feat(localstack): update image version to 4.7.0 and expose ports to all interfaces

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -65,10 +65,10 @@ services:
     tty: true
     restart: ${KALI_RESTART_POLICY-no}
   localstack:
-    image: localstack/localstack:${LOCALSTACK_VERSION-4.6.0}
+    image: localstack/localstack:${LOCALSTACK_VERSION-4.7.0}
     ports:
-      - 127.0.0.1:4566:4566
-      - 127.0.0.1:4510-4559:4510-4559
+      - 4566:4566
+      - 4510-4559:4510-4559
     environment:
       DEBUG: ${DEBUG:-0}
     volumes:


### PR DESCRIPTION
- Bump localstack image from 4.6.0 to 4.7.0
- Change port bindings from 127.0.0.1 to 0.0.0.0 (all interfaces) for ports 4566 and 4510-455
