### PR TITLE
🧪 test: add smoke test for redis service

### DIFF
--- a/tests/smoke/main.sh
+++ b/tests/smoke/main.sh
@@ -15,4 +15,5 @@ sh $FILEDIR/mongo.sh && \
 sh $FILEDIR/nextcloud.sh && \
 sh $FILEDIR/nginx.sh && \
 sh $FILEDIR/phpmyadmin.sh && \
+sh $FILEDIR/redis.sh && \
 sh $FILEDIR/verdaccio.sh

--- a/tests/smoke/redis.sh
+++ b/tests/smoke/redis.sh
@@ -1,0 +1,14 @@
+echo "[Smoke] - Redis\n"
+
+docker compose up -d redis
+
+wait-on tcp:localhost:6379 --timeout 60000
+if [ $? -ne 0 ];
+  then
+    docker compose down -v
+    echo "[Fail]"
+    exit 1
+fi
+
+docker compose down -v
+echo "[Pass]"


### PR DESCRIPTION
🎯 **What:** Missing smoke test for the `redis` service in `compose.yaml`.
📊 **Coverage:** The Redis container is now covered by a smoke test that verifies it can be started and its primary port (6379) becomes available.
✨ **Result:** Better confidence in the continuous integration process ensuring Redis functions as expected within the docker compose environment.

---
*PR created automatically by Jules for task [4337668861790441968](https://jules.google.com/task/4337668861790441968) started by @gabrielrufino*