### PR TITLE
🧪 [Testing Improvement] Add smoke test for mysql service

### DIFF
--- a/tests/smoke/main.sh
+++ b/tests/smoke/main.sh
@@ -12,6 +12,7 @@ sh $FILEDIR/loki.sh && \
 sh $FILEDIR/matomo.sh && \
 sh $FILEDIR/metabase.sh && \
 sh $FILEDIR/mongo.sh && \
+sh $FILEDIR/mysql.sh && \
 sh $FILEDIR/nextcloud.sh && \
 sh $FILEDIR/nginx.sh && \
 sh $FILEDIR/phpmyadmin.sh && \

--- a/tests/smoke/mysql.sh
+++ b/tests/smoke/mysql.sh
@@ -1,0 +1,15 @@
+echo "[Smoke] - Mysql\n"
+
+docker compose up -d mysql
+
+wait-on tcp:localhost:3306 --timeout 60000
+
+if [ $? -ne 0 ];
+  then
+    docker compose down -v
+    echo "[Fail]"
+    exit 1
+fi
+
+docker compose down -v
+echo "[Pass]"


### PR DESCRIPTION
🎯 **What:** Added a missing smoke test for the `mysql` service to improve test coverage.
📊 **Coverage:** The smoke test now covers the happy path of starting the MySQL container, verifying it's accepting connections on port 3306, and tearing it down safely.
✨ **Result:** Improved test coverage and confidence that the MySQL service configuration in the Docker setup functions properly without regressions.

---
*PR created automatically by Jules for task [7788684277237304041](https://jules.google.com/task/7788684277237304041) started by @gabrielrufino*