### PR TITLE
🧪 [Testing] Add smoke test for mariadb

### DIFF
--- a/tests/smoke/main.sh
+++ b/tests/smoke/main.sh
@@ -9,6 +9,7 @@ sh $FILEDIR/gitea.sh && \
 sh $FILEDIR/grafana.sh && \
 sh $FILEDIR/localstack.sh && \
 sh $FILEDIR/loki.sh && \
+sh $FILEDIR/mariadb.sh && \
 sh $FILEDIR/matomo.sh && \
 sh $FILEDIR/metabase.sh && \
 sh $FILEDIR/mongo.sh && \

--- a/tests/smoke/mariadb.sh
+++ b/tests/smoke/mariadb.sh
@@ -1,0 +1,14 @@
+echo "[Smoke] - MariaDB\n"
+
+docker compose up -d mariadb
+
+wait-on tcp:localhost:3307 --timeout 60000
+
+if [ $? -ne 0 ]; then
+  docker compose down -v
+  echo "[Fail]"
+  exit 1
+fi
+
+docker compose down -v
+echo "[Pass]"


### PR DESCRIPTION
🎯 **What:** Added a smoke test for the `mariadb` service in the Docker Compose configuration to address a testing gap.
📊 **Coverage:** The smoke test brings up the `mariadb` container, waits on host port `3307` to become available, and properly cleans up the container and volumes afterward. It is also integrated into the main `tests/smoke/main.sh` suite.
✨ **Result:** Increased testing coverage and confidence that the `mariadb` service starts successfully and correctly binds to its expected port.

---
*PR created automatically by Jules for task [858823104827920675](https://jules.google.com/task/858823104827920675) started by @gabrielrufino*