### PR TITLE
🧪 Add postgres smoke test to test database initialization

### DIFF
--- a/tests/smoke/main.sh
+++ b/tests/smoke/main.sh
@@ -15,4 +15,5 @@ sh $FILEDIR/mongo.sh && \
 sh $FILEDIR/nextcloud.sh && \
 sh $FILEDIR/nginx.sh && \
 sh $FILEDIR/phpmyadmin.sh && \
+sh $FILEDIR/postgres.sh && \
 sh $FILEDIR/verdaccio.sh

--- a/tests/smoke/postgres.sh
+++ b/tests/smoke/postgres.sh
@@ -1,0 +1,19 @@
+echo "[Smoke] - Postgres\n"
+
+docker compose up -d postgres
+
+wait-on tcp:localhost:5432 --timeout 60000
+
+# Retry pg_isready up to 10 times to ensure database is actually initialized
+for i in {1..10}; do
+  if docker compose exec -T postgres pg_isready -U root; then
+    docker compose down -v
+    echo "[Pass]"
+    exit 0
+  fi
+  sleep 2
+done
+
+docker compose down -v
+echo "[Fail]"
+exit 1

--- a/tests/smoke/postgres.sh
+++ b/tests/smoke/postgres.sh
@@ -5,13 +5,15 @@ docker compose up -d postgres
 wait-on tcp:localhost:5432 --timeout 60000
 
 # Retry pg_isready up to 10 times to ensure database is actually initialized
-for i in {1..10}; do
+i=0
+while [ $i -lt 10 ]; do
   if docker compose exec -T postgres pg_isready -U root; then
     docker compose down -v
     echo "[Pass]"
     exit 0
   fi
   sleep 2
+  i=$((i+1))
 done
 
 docker compose down -v


### PR DESCRIPTION
🎯 **What:** The missing smoke test for the `postgres` service has been added to ensure the service can start and become fully ready in our local Docker Compose environment.
📊 **Coverage:** The test ensures that the `postgres` container starts, exposes port `5432`, and is actively accepting connections (via `pg_isready`).
✨ **Result:** Increased testing coverage and robustness, as we can verify regressions in postgres initialization directly within the CI environment.

---
*PR created automatically by Jules for task [1093237254729677065](https://jules.google.com/task/1093237254729677065) started by @gabrielrufino*