### PR TITLE
develop

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -72,6 +72,7 @@ services:
       - traefik.http.routers.gitea.rule=Host(`${GITEA_TRAEFIK_HOST-gitea.localhost}`)
       - traefik.http.routers.gitea.tls=true
       - traefik.http.routers.gitea.tls.certresolver=letsencrypt
+      - traefik.http.services.gitea.loadbalancer.server.port=3000
     logging: *default-logging
     restart: ${GITEA_RESTART_POLICY-no}
   grafana:

--- a/compose.yaml
+++ b/compose.yaml
@@ -57,7 +57,7 @@ services:
     logging: *default-logging
     restart: ${FEDORA_RESTART_POLICY-no}
   gitea:
-    image: gitea/gitea:${GITEA_VERSION-1.18.0}
+    image: gitea/gitea:${GITEA_VERSION-1.27.0}
     environment:
       USER_UID: 1000
       USER_GID: 1000
@@ -67,6 +67,11 @@ services:
       - /etc/localtime:/etc/localtime:ro
     ports:
       - 3002:3000
+    labels:
+      - traefik.enable=true
+      - traefik.http.routers.gitea.rule=Host(`${GITEA_TRAEFIK_HOST-gitea.localhost}`)
+      - traefik.http.routers.gitea.tls=true
+      - traefik.http.routers.gitea.tls.certresolver=letsencrypt
     logging: *default-logging
     restart: ${GITEA_RESTART_POLICY-no}
   grafana:

--- a/tests/smoke/main.sh
+++ b/tests/smoke/main.sh
@@ -15,4 +15,5 @@ sh $FILEDIR/mongo.sh && \
 sh $FILEDIR/nextcloud.sh && \
 sh $FILEDIR/nginx.sh && \
 sh $FILEDIR/phpmyadmin.sh && \
+sh $FILEDIR/postgres.sh && \
 sh $FILEDIR/verdaccio.sh

--- a/tests/smoke/main.sh
+++ b/tests/smoke/main.sh
@@ -12,6 +12,7 @@ sh $FILEDIR/loki.sh && \
 sh $FILEDIR/matomo.sh && \
 sh $FILEDIR/metabase.sh && \
 sh $FILEDIR/mongo.sh && \
+sh $FILEDIR/mysql.sh && \
 sh $FILEDIR/nextcloud.sh && \
 sh $FILEDIR/nginx.sh && \
 sh $FILEDIR/phpmyadmin.sh && \

--- a/tests/smoke/main.sh
+++ b/tests/smoke/main.sh
@@ -15,4 +15,5 @@ sh $FILEDIR/mongo.sh && \
 sh $FILEDIR/nextcloud.sh && \
 sh $FILEDIR/nginx.sh && \
 sh $FILEDIR/phpmyadmin.sh && \
+sh $FILEDIR/redis.sh && \
 sh $FILEDIR/verdaccio.sh

--- a/tests/smoke/main.sh
+++ b/tests/smoke/main.sh
@@ -9,6 +9,7 @@ sh $FILEDIR/gitea.sh && \
 sh $FILEDIR/grafana.sh && \
 sh $FILEDIR/localstack.sh && \
 sh $FILEDIR/loki.sh && \
+sh $FILEDIR/mariadb.sh && \
 sh $FILEDIR/matomo.sh && \
 sh $FILEDIR/metabase.sh && \
 sh $FILEDIR/mongo.sh && \

--- a/tests/smoke/mariadb.sh
+++ b/tests/smoke/mariadb.sh
@@ -1,0 +1,14 @@
+echo "[Smoke] - MariaDB\n"
+
+docker compose up -d mariadb
+
+wait-on tcp:localhost:3307 --timeout 60000
+
+if [ $? -ne 0 ]; then
+  docker compose down -v
+  echo "[Fail]"
+  exit 1
+fi
+
+docker compose down -v
+echo "[Pass]"

--- a/tests/smoke/mysql.sh
+++ b/tests/smoke/mysql.sh
@@ -1,0 +1,15 @@
+echo "[Smoke] - Mysql\n"
+
+docker compose up -d mysql
+
+wait-on tcp:localhost:3306 --timeout 60000
+
+if [ $? -ne 0 ];
+  then
+    docker compose down -v
+    echo "[Fail]"
+    exit 1
+fi
+
+docker compose down -v
+echo "[Pass]"

--- a/tests/smoke/postgres.sh
+++ b/tests/smoke/postgres.sh
@@ -1,0 +1,19 @@
+echo "[Smoke] - Postgres\n"
+
+docker compose up -d postgres
+
+wait-on tcp:localhost:5432 --timeout 60000
+
+# Retry pg_isready up to 10 times to ensure database is actually initialized
+for i in {1..10}; do
+  if docker compose exec -T postgres pg_isready -U root; then
+    docker compose down -v
+    echo "[Pass]"
+    exit 0
+  fi
+  sleep 2
+done
+
+docker compose down -v
+echo "[Fail]"
+exit 1

--- a/tests/smoke/postgres.sh
+++ b/tests/smoke/postgres.sh
@@ -3,6 +3,11 @@ echo "[Smoke] - Postgres\n"
 docker compose up -d postgres
 
 wait-on tcp:localhost:5432 --timeout 60000
+if [ $? -ne 0 ]; then
+  docker compose down -v
+  echo "[Fail]"
+  exit 1
+fi
 
 # Retry pg_isready up to 10 times to ensure database is actually initialized
 i=0

--- a/tests/smoke/postgres.sh
+++ b/tests/smoke/postgres.sh
@@ -1,9 +1,8 @@
-echo "[Smoke] - Postgres\n"
+printf "[Smoke] - Postgres\n"
 
 docker compose up -d postgres
 
-wait-on tcp:localhost:5432 --timeout 60000
-if [ $? -ne 0 ]; then
+if ! wait-on tcp:localhost:5432 --timeout 60000; then
   docker compose down -v
   echo "[Fail]"
   exit 1

--- a/tests/smoke/postgres.sh
+++ b/tests/smoke/postgres.sh
@@ -5,13 +5,15 @@ docker compose up -d postgres
 wait-on tcp:localhost:5432 --timeout 60000
 
 # Retry pg_isready up to 10 times to ensure database is actually initialized
-for i in {1..10}; do
+i=0
+while [ $i -lt 10 ]; do
   if docker compose exec -T postgres pg_isready -U root; then
     docker compose down -v
     echo "[Pass]"
     exit 0
   fi
   sleep 2
+  i=$((i+1))
 done
 
 docker compose down -v

--- a/tests/smoke/redis.sh
+++ b/tests/smoke/redis.sh
@@ -1,0 +1,14 @@
+echo "[Smoke] - Redis\n"
+
+docker compose up -d redis
+
+wait-on tcp:localhost:6379 --timeout 60000
+if [ $? -ne 0 ];
+  then
+    docker compose down -v
+    echo "[Fail]"
+    exit 1
+fi
+
+docker compose down -v
+echo "[Pass]"


### PR DESCRIPTION
- **test: add smoke test for redis service**
- **add smoke test for mysql service**
- **Add smoke test for mariadb service**
- **Add postgres smoke test to verify compose setup**
- **Fix bashism in test script**
- **chore(gitea): upgrade to 1.27.0 and add traefik labels**
- **test(postgres): fail fast if wait-on times out**
- **fix(gitea): add traefik loadbalancer port label**
- **fix(tests/smoke/postgres): fix shellcheck warnings SC2028 and SC2181**
